### PR TITLE
デフォルトパラメータが先頭に来ていたコードを修正

### DIFF
--- a/PluginManager.php
+++ b/PluginManager.php
@@ -75,7 +75,7 @@ class PluginManager extends AbstractPluginManager
      *
      * @throws \Exception
      */
-    public function enable(array $meta = null, ContainerInterface $container)
+    public function enable(array $meta, ContainerInterface $container)
     {
         $entityManager = $container->get('doctrine')->getManager();
         $this->copyBlock($container);
@@ -90,7 +90,7 @@ class PluginManager extends AbstractPluginManager
      * @param array|null $meta
      * @param ContainerInterface $container
      */
-    public function disable(array $meta = null, ContainerInterface $container)
+    public function disable(array $meta, ContainerInterface $container)
     {
         $this->removeDataBlock($container);
     }
@@ -99,7 +99,7 @@ class PluginManager extends AbstractPluginManager
      * @param array|null $meta
      * @param ContainerInterface $container
      */
-    public function update(array $meta = null, ContainerInterface $container)
+    public function update(array $meta, ContainerInterface $container)
     {
         $this->copyBlock($container);
     }


### PR DESCRIPTION
デフォルトパラメータがそうでないパラメータより先に定義されているため、修正しました
(パラメータの参照はなし)