### PR TITLE
モーダルの決定ボタンを、本体のモーダルのスタイルに統一

### DIFF
--- a/Resource/template/admin/search_product.twig
+++ b/Resource/template/admin/search_product.twig
@@ -75,7 +75,7 @@
                             {% endif %}
                         </span>
                     </td>
-                    <td class="text-end">
+                    <td class="align-middle text-end">
                         <button onclick="fnSelectProduct($(this).parent().parent(), '{{ Product.id }}', '{{ Product.name|escape('js') }}', '{{ url('admin_product_product_edit', { id : Product.id }) }}', '{{ asset(Product.mainFileName|no_image_product, 'save_image') }}', '{{ Product.code_min }}', '{{ Product.code_max }}')" type="button" class="btn btn-default btn-sm">
                             <i class="fa fa-plus fa-lg fw-bold text-secondary"></i>
                         </button>

--- a/Resource/template/admin/search_product.twig
+++ b/Resource/template/admin/search_product.twig
@@ -77,7 +77,7 @@
                     </td>
                     <td class="text-end">
                         <button onclick="fnSelectProduct($(this).parent().parent(), '{{ Product.id }}', '{{ Product.name|escape('js') }}', '{{ url('admin_product_product_edit', { id : Product.id }) }}', '{{ asset(Product.mainFileName|no_image_product, 'save_image') }}', '{{ Product.code_min }}', '{{ Product.code_max }}')" type="button" class="btn btn-default btn-sm">
-                            決定
+                            <i class="fa fa-plus fa-lg fw-bold text-secondary"></i>
                         </button>
                     </td>
                 </tr>


### PR DESCRIPTION
[#55](https://github.com/EC-CUBE/Recommend-plugin/issues/55)の対応です

本体側の受注管理＞受注登録の「商品を追加」ボタンで表示されるダイアログに統一する形で、“＋”としました
また、＋が上下中央に配置されるようにしました

![image](https://user-images.githubusercontent.com/8424850/187035913-86021ca5-d1e9-495b-b0ec-a815c8a0891d.png)

