### PR TITLE
削除モーダルのメッセージ表示をEC-CUBE本体に統一

### DIFF
--- a/Resource/locale/messages.ja.yml
+++ b/Resource/locale/messages.ja.yml
@@ -13,7 +13,8 @@ plugin_recommend.admin.index.total_num: <strong>%number% 件</strong> が該当�
 plugin_recommend.admin.index.col2: 商品画像
 plugin_recommend.admin.index.col3: 商品名
 plugin_recommend.admin.index.col4: 説明文
-plugin_recommend.admin.index.delete.confirm: このおすすめ商品を削除しても宜しいですか？
+plugin_recommend.admin.index.delete__confirm_title: このおすすめ商品を削除します
+plugin_recommend.admin.index.delete__confirm_message: このおすすめ商品を削除しても宜しいですか？
 plugin_recommend.admin.notice: 項目の順番はドラッグ＆ドロップでも変更可能です。
 plugin_recommend.admin.new: おすすめ商品を新規登録
 

--- a/Resource/template/admin/index.twig
+++ b/Resource/template/admin/index.twig
@@ -138,13 +138,13 @@
                                                 <div class="modal-dialog" role="document">
                                                     <div class="modal-content">
                                                         <div class="modal-header">
-                                                            <h5 class="modal-title font-weight-bold">
-                                                                {{ 'plugin_recommend.admin.index.delete.confirm'|trans }}</h5>
+                                                            <h5 class="modal-title fw-bold">
+                                                                {{ 'plugin_recommend.admin.index.delete__confirm_title'|trans }}</h5>
                                                             <button class="btn-close" type="button" data-bs-dismiss="modal" aria-label="Close"></button>
                                                         </div>
                                                         <div class="modal-body text-start">
                                                             <p class="text-start">
-                                                                {{ 'plugin_recommend.admin.index.delete.confirm'|trans }}</p>
+                                                                {{ 'plugin_recommend.admin.index.delete__confirm_message'|trans }}</p>
                                                         </div>
                                                         <div class="modal-footer">
                                                             <button class="btn btn-ec-sub" type="button"


### PR DESCRIPTION
クーポンプラグの[#169](https://github.com/EC-CUBE/coupon-plugin/pull/169)に合わせ、メッセージを修正しました