### PR TITLE
ボタンのメッセージを修正

### DIFF
--- a/Resource/locale/messages.ja.yml
+++ b/Resource/locale/messages.ja.yml
@@ -24,6 +24,6 @@ plugin_recommend.admin.edit.product: 商品
 plugin_recommend.admin.edit.comment: 説明文
 plugin_recommend.admin.edit.comment.help: （最大%number%文字）
 plugin_recommend.admin.edit.existed: この商品はすでにおすすめ商品として登録されています。
-plugin_recommend.admin.edit.search: 商品の追加
+plugin_recommend.admin.edit.search: 商品の選択
 plugin_recommend.admin.edit.product_search.header: 商品検索
 plugin_recommend.admin.edit.product_search.button: 検索


### PR DESCRIPTION
商品の編集時にも、「商品の追加」と表示され、商品が追加できるように思われるため
他と合わせて、「商品の選択」としました。

![image](https://user-images.githubusercontent.com/8424850/187711383-c8b6cdc9-ee50-4ec3-bc0f-8c2fd8dfc62a.png)
