### PR TITLE
RecommendProductエンティティをプラグインで拡張するとプラグインの更新時にエラーが発生するバグ修正

### DIFF
--- a/Entity/RecommendProduct.php
+++ b/Entity/RecommendProduct.php
@@ -17,236 +17,238 @@ use Doctrine\ORM\Mapping as ORM;
 use Eccube\Entity\AbstractEntity;
 use Eccube\Entity\Product;
 
-/**
- * RecommendProduct
- *
- * @ORM\Table(name="plg_recommend_product")
- * @ORM\InheritanceType("SINGLE_TABLE")
- * @ORM\DiscriminatorColumn(name="discriminator_type", type="string", length=255)
- * @ORM\HasLifecycleCallbacks()
- * @ORM\Entity(repositoryClass="Plugin\Recommend42\Repository\RecommendProductRepository")
- */
-class RecommendProduct extends AbstractEntity
-{
+if (!class_exists(RecommendProduct::class)) {
     /**
-     * @var int
+     * RecommendProduct
      *
-     * @ORM\Column(name="recommend_id", type="integer", options={"unsigned":true})
-     * @ORM\Id
-     * @ORM\GeneratedValue(strategy="IDENTITY")
+     * @ORM\Table(name="plg_recommend_product")
+     * @ORM\InheritanceType("SINGLE_TABLE")
+     * @ORM\DiscriminatorColumn(name="discriminator_type", type="string", length=255)
+     * @ORM\HasLifecycleCallbacks()
+     * @ORM\Entity(repositoryClass="Plugin\Recommend42\Repository\RecommendProductRepository")
      */
-    private $id;
-
-    /**
-     * @var string
-     *
-     * @ORM\Column(name="comment", type="text", nullable=true)
-     */
-    private $comment;
-
-    /**
-     * @var int
-     *
-     * @ORM\Column(name="sort_no", type="integer", nullable=true)
-     */
-    private $sort_no;
-
-    /**
-     * @var boolean
-     *
-     * @ORM\Column(name="visible", type="boolean", options={"default":true})
-     */
-    private $visible;
-
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="create_date", type="datetimetz")
-     */
-    private $create_date;
-
-    /**
-     * @var \DateTime
-     *
-     * @ORM\Column(name="update_date", type="datetimetz")
-     */
-    private $update_date;
-
-    /**
-     * @var \Eccube\Entity\Product
-     *
-     * @ORM\OneToOne(targetEntity="Eccube\Entity\Product")
-     * @ORM\JoinColumns({
-     *   @ORM\JoinColumn(name="product_id", referencedColumnName="id")
-     * })
-     */
-    private $Product;
-
-    /**
-     * Get recommend product id.
-     *
-     * @return int
-     */
-    public function getId()
+    class RecommendProduct extends AbstractEntity
     {
-        return $this->id;
-    }
+        /**
+         * @var int
+         *
+         * @ORM\Column(name="recommend_id", type="integer", options={"unsigned":true})
+         * @ORM\Id
+         * @ORM\GeneratedValue(strategy="IDENTITY")
+         */
+        private $id;
 
-    /**
-     * Set recommend product id.
-     *
-     * @param int $id
-     *
-     * @return $this
-     */
-    public function setId($id)
-    {
-        $this->id = $id;
+        /**
+         * @var string
+         *
+         * @ORM\Column(name="comment", type="text", nullable=true)
+         */
+        private $comment;
 
-        return $this;
-    }
+        /**
+         * @var int
+         *
+         * @ORM\Column(name="sort_no", type="integer", nullable=true)
+         */
+        private $sort_no;
 
-    /**
-     * Get commend.
-     *
-     * @return string
-     */
-    public function getComment()
-    {
-        return $this->comment;
-    }
+        /**
+         * @var boolean
+         *
+         * @ORM\Column(name="visible", type="boolean", options={"default":true})
+         */
+        private $visible;
 
-    /**
-     * Set comment.
-     *
-     * @param string $comment
-     *
-     * @return $this
-     */
-    public function setComment($comment)
-    {
-        $this->comment = $comment;
+        /**
+         * @var \DateTime
+         *
+         * @ORM\Column(name="create_date", type="datetimetz")
+         */
+        private $create_date;
 
-        return $this;
-    }
+        /**
+         * @var \DateTime
+         *
+         * @ORM\Column(name="update_date", type="datetimetz")
+         */
+        private $update_date;
 
-    /**
-     * Get rank.
-     *
-     * @return int
-     */
-    public function getSortno()
-    {
-        return $this->sort_no;
-    }
+        /**
+         * @var \Eccube\Entity\Product
+         *
+         * @ORM\OneToOne(targetEntity="Eccube\Entity\Product")
+         * @ORM\JoinColumns({
+         *   @ORM\JoinColumn(name="product_id", referencedColumnName="id")
+         * })
+         */
+        private $Product;
 
-    /**
-     * Set rank.
-     *
-     * @param int $sort_no
-     *
-     * @return $this
-     */
-    public function setSortno($sort_no)
-    {
-        $this->sort_no = $sort_no;
+        /**
+         * Get recommend product id.
+         *
+         * @return int
+         */
+        public function getId()
+        {
+            return $this->id;
+        }
 
-        return $this;
-    }
+        /**
+         * Set recommend product id.
+         *
+         * @param int $id
+         *
+         * @return $this
+         */
+        public function setId($id)
+        {
+            $this->id = $id;
 
-    /**
-     * Set visible.
-     *
-     * @param bool $visible
-     *
-     * @return $this
-     */
-    public function setVisible($visible)
-    {
-        $this->visible = $visible;
+            return $this;
+        }
 
-        return $this;
-    }
+        /**
+         * Get commend.
+         *
+         * @return string
+         */
+        public function getComment()
+        {
+            return $this->comment;
+        }
 
-    /**
-     * Get del_flg.
-     *
-     * @return bool
-     */
-    public function getVisible()
-    {
-        return $this->visible;
-    }
+        /**
+         * Set comment.
+         *
+         * @param string $comment
+         *
+         * @return $this
+         */
+        public function setComment($comment)
+        {
+            $this->comment = $comment;
 
-    /**
-     * Set create_date.
-     *
-     * @param \DateTime $createDate
-     *
-     * @return $this
-     */
-    public function setCreateDate($createDate)
-    {
-        $this->create_date = $createDate;
+            return $this;
+        }
 
-        return $this;
-    }
+        /**
+         * Get rank.
+         *
+         * @return int
+         */
+        public function getSortno()
+        {
+            return $this->sort_no;
+        }
 
-    /**
-     * Get create_date.
-     *
-     * @return \DateTime
-     */
-    public function getCreateDate()
-    {
-        return $this->create_date;
-    }
+        /**
+         * Set rank.
+         *
+         * @param int $sort_no
+         *
+         * @return $this
+         */
+        public function setSortno($sort_no)
+        {
+            $this->sort_no = $sort_no;
 
-    /**
-     * Set update_date.
-     *
-     * @param \DateTime $updateDate
-     *
-     * @return $this
-     */
-    public function setUpdateDate($updateDate)
-    {
-        $this->update_date = $updateDate;
+            return $this;
+        }
 
-        return $this;
-    }
+        /**
+         * Set visible.
+         *
+         * @param bool $visible
+         *
+         * @return $this
+         */
+        public function setVisible($visible)
+        {
+            $this->visible = $visible;
 
-    /**
-     * Get update_date.
-     *
-     * @return \DateTime
-     */
-    public function getUpdateDate()
-    {
-        return $this->update_date;
-    }
+            return $this;
+        }
 
-    /**
-     * Set Product.
-     *
-     * @param \Eccube\Entity\Product $Product
-     *
-     * @return $this
-     */
-    public function setProduct(Product $Product)
-    {
-        $this->Product = $Product;
+        /**
+         * Get del_flg.
+         *
+         * @return bool
+         */
+        public function getVisible()
+        {
+            return $this->visible;
+        }
 
-        return $this;
-    }
+        /**
+         * Set create_date.
+         *
+         * @param \DateTime $createDate
+         *
+         * @return $this
+         */
+        public function setCreateDate($createDate)
+        {
+            $this->create_date = $createDate;
 
-    /**
-     * Get Product.
-     *
-     * @return \Eccube\Entity\Product|null
-     */
-    public function getProduct()
-    {
-        return $this->Product;
+            return $this;
+        }
+
+        /**
+         * Get create_date.
+         *
+         * @return \DateTime
+         */
+        public function getCreateDate()
+        {
+            return $this->create_date;
+        }
+
+        /**
+         * Set update_date.
+         *
+         * @param \DateTime $updateDate
+         *
+         * @return $this
+         */
+        public function setUpdateDate($updateDate)
+        {
+            $this->update_date = $updateDate;
+
+            return $this;
+        }
+
+        /**
+         * Get update_date.
+         *
+         * @return \DateTime
+         */
+        public function getUpdateDate()
+        {
+            return $this->update_date;
+        }
+
+        /**
+         * Set Product.
+         *
+         * @param \Eccube\Entity\Product $Product
+         *
+         * @return $this
+         */
+        public function setProduct(Product $Product)
+        {
+            $this->Product = $Product;
+
+            return $this;
+        }
+
+        /**
+         * Get Product.
+         *
+         * @return \Eccube\Entity\Product|null
+         */
+        public function getProduct()
+        {
+            return $this->Product;
+        }
     }
 }


### PR DESCRIPTION
RecommendProductエンティティをプラグインで拡張するとプラグインの更新時にエラーが発生します。

インストール時や有効化時にはエラーが発生しなかったので本体の修正をするべきなのかもしれませんが、
急ぎの案件があるのでこちらを取り込んで公開していただけると助かります。